### PR TITLE
fix(#6): replace Bun.wrapAnsi global with runtime check and ANSI-aware fallback

### DIFF
--- a/src/tui/colors.ts
+++ b/src/tui/colors.ts
@@ -90,7 +90,12 @@ export function lifecycleFg(status: string): string {
 
 const ESC = "\x1b";
 
-function ansiSequenceEnd(text: string, start: number): number {
+/**
+ * Returns the position after an ANSI escape sequence at the given start index,
+ * or -1 if the character at start is not the beginning of an escape sequence.
+ * Handles CSI (cursor/color), OSC (hyperlinks), DCS/PM/APC, and C1 CSI sequences.
+ */
+export function ansiSequenceEnd(text: string, start: number): number {
 	const first = text[start];
 	if (first === ESC) {
 		const second = text[start + 1];
@@ -180,7 +185,17 @@ function isFullWidthCodePoint(codePoint: number): boolean {
 	);
 }
 
-function codePointDisplayWidth(codePoint: number): number {
+/**
+ * Display width of a single Unicode code point in terminal columns.
+ * Returns 0 for control characters, combining marks, zero-width joiners, and variation selectors.
+ * Returns 2 for full-width characters (CJK, emoji).
+ * Returns 1 for all other characters (ASCII, most scripts).
+ * Surrogate code points (0xD800-0xDFFF) return 0 (they should not appear in valid strings).
+ */
+export function codePointDisplayWidth(codePoint: number): number {
+	// Validate input: only valid Unicode code points (0x0 - 0x10FFFF)
+	// Reject surrogates which are not valid code points for string representation
+	if (codePoint < 0 || codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) return 0;
 	if (codePoint <= 0x1f || (codePoint >= 0x7f && codePoint <= 0x9f)) return 0;
 	if (codePoint === 0x200d) return 0; // ZWJ
 	if (codePoint >= 0xfe00 && codePoint <= 0xfe0f) return 0; // variation selectors

--- a/src/tui/components/markdown.ts
+++ b/src/tui/components/markdown.ts
@@ -1,6 +1,6 @@
 import { marked, type Token } from "marked";
 import { UI_MARKDOWN_CACHE_LIMIT } from "../../config/constants";
-import { BOLD, BOX, FG, RESET_FG, UNBOLD, visibleWidth } from "../colors";
+import { ansiSequenceEnd, BOLD, BOX, codePointDisplayWidth, FG, RESET_FG, UNBOLD, visibleWidth } from "../colors";
 
 const ITALIC = "\x1b[3m";
 const UNITALIC = "\x1b[23m";
@@ -40,10 +40,59 @@ type MarkdownTableToken = MarkdownToken & {
 	rows?: MarkdownTableCell[][];
 };
 
+/**
+ * Wrap an ANSI-colored line at a specified display width (hard wrap).
+ * Preserves ANSI escape sequences and handles multi-byte characters correctly.
+ * Single characters may exceed the specified width (hard wrap semantics).
+ * Incomplete ANSI sequences (e.g., line ending with ESC but no final byte) are preserved verbatim.
+ */
 function wrapAnsiLine(line: string, width: number): string[] {
 	if (width <= 0) return [];
 	if (!line) return [""];
-	return Bun.wrapAnsi(line, width, { hard: true }).split("\n");
+	if (typeof Bun.wrapAnsi === "function") {
+		try {
+			return Bun.wrapAnsi(line, width, { hard: true }).split("\n");
+		} catch {
+			// Fall through to fallback if Bun.wrapAnsi throws
+		}
+	}
+	// Fallback: code-point-aware hard wrap using ansiSequenceEnd and codePointDisplayWidth
+	const result: string[] = [];
+	let current = "";
+	let currentWidth = 0;
+	let i = 0;
+	while (i < line.length) {
+		// Check for ANSI escape sequence using the same logic as visibleWidth.
+		// ansiSequenceEnd returns -1 if character at i is not an escape, or the
+		// position after the escape sequence if it is one.
+		const ansiEnd = ansiSequenceEnd(line, i);
+		if (ansiEnd > i) {
+			// Preserve the original bytes of the ANSI sequence (may be incomplete).
+			current += line.slice(i, ansiEnd);
+			i = ansiEnd;
+			continue;
+		}
+		// Get next code point (handles multi-byte UTF-16 correctly).
+		const codePoint = line.codePointAt(i);
+		if (codePoint === undefined) break;
+		// Measure display width directly from code point (O(1) lookup).
+		// Width 0: control chars, combining marks, ZWJ
+		// Width 1: ASCII, most scripts
+		// Width 2: CJK, emoji
+		const charWidth = codePointDisplayWidth(codePoint);
+		if (currentWidth + charWidth > width && current.length > 0) {
+			result.push(current);
+			current = "";
+			currentWidth = 0;
+		}
+		// Preserve the original bytes from the source string (not reconstructed).
+		const charSize = codePoint > 0xffff ? 2 : 1;
+		current += line.slice(i, i + charSize);
+		currentWidth += charWidth;
+		i += charSize;
+	}
+	if (current) result.push(current);
+	return result.length > 0 ? result : [""];
 }
 
 function wrapAnsiText(text: string, width: number): string[] {


### PR DESCRIPTION
## Summary

- `Bun.wrapAnsi` is undefined on the `Bun` global at runtime in Bun 1.3.5, causing 3 test failures in TasksDetailsPane
- Added runtime `typeof` check with try-catch to use `Bun.wrapAnsi` when available (future-proofing)
- Implemented ANSI-aware hard-wrap fallback using existing `ansiSequenceEnd()` and `codePointDisplayWidth()` helpers
- Exported two previously-private functions from `colors.ts` with JSDoc documentation

## Test Results

- **Before**: 126 pass, 3 fail
- **After**: 129 pass, 0 fail

Fixes #6